### PR TITLE
Subclass of  ActorType, DispatcherType is restricted to be a class not a struct

### DIFF
--- a/Sources/ActorType.swift
+++ b/Sources/ActorType.swift
@@ -8,7 +8,7 @@
 
 import RxSwift
 
-public protocol ActorType: ObserverType where E == Action {
+public protocol ActorType: ObserverType where E == Action, Self : AnyObject {
     associatedtype Action
     func onDispatch(_ action: Action)
 }

--- a/Sources/DispatcherType.swift
+++ b/Sources/DispatcherType.swift
@@ -16,7 +16,7 @@ public enum Dispatch<Action> {
     case void
 }
 
-public protocol DispatcherType: ObserverType {
+public protocol DispatcherType: ObserverType where Self : AnyObject {
     associatedtype Action
     
     var disposeBag: DisposeBag { get }


### PR DESCRIPTION
Extensions of ActorType and DispatcherType use `objc_getAssociatedObject` and `objc_setAssociatedObject`. But these functions works only on swift's class and ObjC's NSObject. We need to restrict that Subclass of ActorType and DispatcherType is a swift's class.